### PR TITLE
refactor(context): Switch to new context API

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -34,9 +34,6 @@
     ]
   ],
   "env": {
-    "development": {
-      "plugins": ["flow-react-proptypes"]
-    },
     "test": {
       "plugins": [
         [

--- a/.eslintrc
+++ b/.eslintrc
@@ -31,7 +31,6 @@
   "rules": {
     "no-console": 2,
     "jsx-a11y/href-no-hash": 0,
-    "react/prop-types": 0,
     "react/no-deprecated": 2,
     "react/jsx-filename-extension": 0,
     "react/require-default-props": 0,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "babel-cli": "6.26.0",
     "babel-eslint": "8.2.6",
     "babel-jest": "23.4.2",
-    "babel-plugin-flow-react-proptypes": "24.1.1",
     "babel-plugin-lodash": "3.3.4",
     "babel-plugin-macros": "2.4.0",
     "babel-plugin-module-resolver": "3.1.1",
@@ -51,7 +50,7 @@
     "cross-env": "5.2.0",
     "css-loader": "0.28.11",
     "enzyme": "3.4.4",
-    "enzyme-adapter-react-16": "1.2.0",
+    "enzyme-adapter-react-16.3": "1.0.0",
     "enzyme-to-json": "3.3.4",
     "eslint": "4.17.0",
     "eslint-config-airbnb": "16.1.0",
@@ -141,9 +140,7 @@
     "verifyConditions": "condition-circle"
   },
   "peerDependencies": {
-    "prop-types": ">=15",
-    "react": ">=15",
-    "react-dom": ">=15"
+    "react": ">=16.3"
   },
   "dependencies": {
     "cxs": "https://github.com/arahansen/cxs#d593d14e708c4f5c17cb2105cb9435ae87ade362",

--- a/scripts/webpack.config.js
+++ b/scripts/webpack.config.js
@@ -46,8 +46,6 @@ module.exports = {
   devtool: 'source-map',
   externals: {
     react: 'react',
-    'react-dom': 'react-dom',
-    'prop-types': 'prop-types',
   },
   module: {
     rules: [

--- a/src/asCol/asCol.spec.js
+++ b/src/asCol/asCol.spec.js
@@ -26,7 +26,7 @@ describe('Col', () => {
     expect(wrapper.find('strong').length).toBe(1)
   })
 
-  fit('should not error when passed valid props', () => {
+  it('should not error when passed valid props', () => {
     spyOn(log, 'error')
 
     wrapper = mount(<Col margin={0} />)

--- a/src/asGrid/index.js
+++ b/src/asGrid/index.js
@@ -1,16 +1,12 @@
 // @flow
 import * as React from 'react'
 import { compact } from 'lodash'
-import type {
-  OneResolutionGrid,
-  ConfigProviderContext,
-  GridProps,
-  OneResolution,
-} from '../types'
+import type { OneResolutionGrid, GridProps, OneResolution } from '../types'
 import { styles, getCol } from './grid.styles'
 import { getValue } from '../utils'
 import getCoreStyles from '../core'
 import withResolution from '../withResolution'
+import { configProviderContext } from '../configProvider'
 
 const resolutionProperties = ['align', 'justify', 'size']
 
@@ -20,27 +16,36 @@ export default function asGrid(
     props: $Shape<OneResolution>
   ) => $Shape<OneResolution> = props => props
 ): React.ComponentType<GridProps> {
-  function Grid(
-    {
-      align,
-      className,
-      justify,
-      size,
-      innerRef,
-      ...restProps
-    }: OneResolutionGrid,
-    context: ConfigProviderContext
-  ) {
-    const props = getCoreStyles(mapDefaultProps(restProps), context)
-    const classes = compact([
-      styles.grid,
-      getCol(size, getValue(context, 'columns')),
-      className,
-      align && styles[`${align}Align`],
-      justify && styles[`${justify}Justify`],
-    ])
+  function Grid({
+    align,
+    className,
+    justify,
+    size,
+    innerRef,
+    ...restProps
+  }: OneResolutionGrid) {
+    return (
+      <configProviderContext.Consumer>
+        {context => {
+          const props = getCoreStyles(mapDefaultProps(restProps), context)
+          const classes = compact([
+            styles.grid,
+            getCol(size, getValue(context, 'columns')),
+            className,
+            align && styles[`${align}Align`],
+            justify && styles[`${justify}Justify`],
+          ])
 
-    return <Component ref={innerRef} {...props} className={classes.join(' ')} />
+          return (
+            <Component
+              ref={innerRef}
+              {...props}
+              className={classes.join(' ')}
+            />
+          )
+        }}
+      </configProviderContext.Consumer>
+    )
   }
 
   return withResolution(Grid, resolutionProperties)

--- a/src/asLayout/index.js
+++ b/src/asLayout/index.js
@@ -1,16 +1,12 @@
 // @flow
 import * as React from 'react'
 import { compact } from 'lodash'
-import type {
-  OneResolutionLayout,
-  ConfigProviderContext,
-  LayoutProps,
-  OneResolution,
-} from '../types'
+import type { OneResolutionLayout, LayoutProps, OneResolution } from '../types'
 import getStyles from './layout.styles'
 import getCoreStyles from '../core'
 import { getValues } from '../utils/index'
 import withResolution from '../withResolution'
+import { configProviderContext } from '../configProvider'
 
 const resolutionProperties = ['fixed', 'height', 'overflow']
 
@@ -20,28 +16,37 @@ export default function asLayout(
     props: $Shape<OneResolution>
   ) => $Shape<OneResolution> = props => props
 ): React.ComponentType<LayoutProps> {
-  function Layout(
-    {
-      className,
-      fixed,
-      height,
-      overflow,
-      innerRef,
-      ...restProps
-    }: OneResolutionLayout,
-    context: ConfigProviderContext
-  ) {
-    const props = getCoreStyles(mapDefaultProps(restProps), context)
-    const styles = getStyles(getValues(context, restProps))
-    const classes = compact([
-      className,
-      fixed && styles[`${fixed}Fixed`],
-      height ? styles[`${height}Height`] : styles.fitHeight,
-      overflow && styles.overflow,
-      styles.layout,
-    ])
+  function Layout({
+    className,
+    fixed,
+    height,
+    overflow,
+    innerRef,
+    ...restProps
+  }: OneResolutionLayout) {
+    return (
+      <configProviderContext.Consumer>
+        {context => {
+          const props = getCoreStyles(mapDefaultProps(restProps), context)
+          const styles = getStyles(getValues(context, props))
+          const classes = compact([
+            className,
+            fixed && styles[`${fixed}Fixed`],
+            height ? styles[`${height}Height`] : styles.fitHeight,
+            overflow && styles.overflow,
+            styles.layout,
+          ])
 
-    return <Component ref={innerRef} {...props} className={classes.join(' ')} />
+          return (
+            <Component
+              ref={innerRef}
+              {...props}
+              className={classes.join(' ')}
+            />
+          )
+        }}
+      </configProviderContext.Consumer>
+    )
   }
 
   return withResolution(Layout, resolutionProperties)

--- a/src/col/index.js
+++ b/src/col/index.js
@@ -1,0 +1,31 @@
+// @flow
+import * as React from 'react'
+import Grid from '../grid'
+import { getValues } from '../utils'
+import type { GridProps } from '../types'
+import { configProviderContext } from '../configProvider'
+
+export default function Col(props: GridProps) {
+  if (typeof props.margin !== 'undefined') {
+    return <Grid {...props} />
+  }
+
+  return (
+    <configProviderContext.Consumer>
+      {context => {
+        const { gutter, verticalGutter } = getValues(context, props)
+        return (
+          <Grid
+            {...{
+              marginTop: 0,
+              marginRight: gutter / 2,
+              marginBottom: verticalGutter,
+              marginLeft: gutter / 2,
+            }}
+            {...props}
+          />
+        )
+      }}
+    </configProviderContext.Consumer>
+  )
+}

--- a/src/configProvider/configProvider.spec.js
+++ b/src/configProvider/configProvider.spec.js
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { mount } from 'enzyme'
 import Grid from '../grid'
-import ConfigProvider from './index'
+import ConfigProvider, { configProviderContext } from './index'
 
 describe('ConfigProvider', () => {
   let wrapper
@@ -26,11 +26,19 @@ describe('ConfigProvider', () => {
   })
 
   it('should define gymnast context', () => {
-    wrapper = mount(<ConfigProvider />)
+    let context
 
-    expect(wrapper.context()).toEqual({
-      gymnast: undefined,
-    })
+    wrapper = mount(
+      <ConfigProvider>
+        <configProviderContext.Consumer>
+          {_context => {
+            context = _context
+          }}
+        </configProviderContext.Consumer>
+      </ConfigProvider>
+    )
+
+    expect(context).toEqual({ gutter: 3, verticalGutter: 3 })
   })
 
   afterEach(() => {

--- a/src/configProvider/index.js
+++ b/src/configProvider/index.js
@@ -1,7 +1,8 @@
 // @flow
+/* eslint-disable react/no-unused-prop-types */
 import * as React from 'react'
-import PropTypes from 'prop-types'
 import type {
+  Context,
   ConfigProviderContext,
   DisplayAliases,
   SpacingAliases,
@@ -24,42 +25,27 @@ type Props = {
   verticalGutter?: number,
 }
 
-export const ConfigContextPropTypes = {
-  gymnast: PropTypes.shape({
-    base: PropTypes.number,
-    columns: PropTypes.number,
-    displayAliases: PropTypes.shape({}),
-    fallbackDisplayKey: PropTypes.string,
-    gutter: PropTypes.number,
-    maxPageWidth: PropTypes.oneOf([PropTypes.number, 'none']),
-    minPageWidth: PropTypes.number,
-    pageMargin: PropTypes.shape({}),
-    spacingAliases: PropTypes.shape({}),
-    verticalGutter: PropTypes.number,
-  }),
-}
+/* eslint-disable flowtype/generic-spacing */
+export const configProviderContext: Context<
+  ConfigProviderContext
+> = React.createContext({})
+/* eslint-enable flowtype/generic-spacing */
 
-export default class ConfigProvider extends React.Component<Props> {
-  static contextTypes = ConfigContextPropTypes
-  static childContextTypes = ConfigContextPropTypes
-
-  getChildContext(): ConfigProviderContext {
-    const {
-      gutter = defaults.gutter,
-      verticalGutter = gutter,
-      children,
-      ...props
-    } = this.props
-
-    return {
-      gymnast: {
+export default function ConfigProvider({
+  gutter = defaults.gutter,
+  verticalGutter = gutter,
+  children,
+  ...props
+}: Props) {
+  return (
+    <configProviderContext.Provider
+      value={{
         gutter,
         verticalGutter,
         ...props,
-      },
-    }
-  }
-  render() {
-    return this.props.children || null
-  }
+      }}
+    >
+      {children}
+    </configProviderContext.Provider>
+  )
 }

--- a/src/core/asCore.js
+++ b/src/core/asCore.js
@@ -1,0 +1,73 @@
+// @flow
+import * as React from 'react'
+import type { OneResolution } from '../types'
+import withResolution from '../withResolution'
+import { combineSpacing, getValue } from '../utils'
+import { configProviderContext } from '../configProvider'
+
+const sharedResolutionProperties = [
+  'margin',
+  'marginBottom',
+  'marginLeft',
+  'marginRight',
+  'marginTop',
+  'padding',
+  'paddingBottom',
+  'paddingLeft',
+  'paddingRight',
+  'paddingTop',
+]
+
+export default function asCore(
+  Component: React.ComponentType<*> | string,
+  resolutionProperties: Array<string>
+) {
+  function Core({
+    base,
+    margin,
+    marginBottom,
+    marginLeft,
+    marginRight,
+    marginTop,
+    padding,
+    paddingBottom,
+    paddingLeft,
+    paddingRight,
+    paddingTop,
+    style = {},
+    ...props
+  }: OneResolution) {
+    return (
+      <configProviderContext.Consumer>
+        {context => {
+          const cssStyle = {
+            ...style,
+            ...combineSpacing({
+              spacingProps: {
+                margin,
+                padding,
+                marginTop,
+                marginRight,
+                marginBottom,
+                marginLeft,
+                paddingTop,
+                paddingRight,
+                paddingBottom,
+                paddingLeft,
+              },
+              base: getValue(context, 'base', base),
+              spacingAliases: getValue(context, 'spacingAliases'),
+            }),
+          }
+
+          return <Component {...props} style={cssStyle} />
+        }}
+      </configProviderContext.Consumer>
+    )
+  }
+
+  return withResolution(
+    Core,
+    sharedResolutionProperties.concat(resolutionProperties)
+  )
+}

--- a/src/dev/dev.js
+++ b/src/dev/dev.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import ReactDOM from 'react-dom'
-import { ConfigContextPropTypes } from '../configProvider'
+import { configProviderContext } from '../configProvider'
 import getStyles from './dev.styles'
 import {
   body,
@@ -31,8 +31,6 @@ export default class Dev extends React.Component<Props, State> {
     useCtrl: true,
     useShift: true,
   }
-
-  static contextTypes = ConfigContextPropTypes
 
   state = {
     showOverlay: false,
@@ -67,25 +65,32 @@ export default class Dev extends React.Component<Props, State> {
     if (!this.state.showOverlay) {
       return null
     }
-    const values = getValues(this.context)
-    const styles = getStyles(values)
-    const content = (
-      <Layout className={styles.gymnastOverlay}>
-        <div className={styles.leftMargin} />
-        <Root>
-          {times(values.columns).map(key => (
-            <Grid
-              margin={[0, values.gutter / 2]}
-              key={key}
-              size={1}
-              className={styles.col}
-            />
-          ))}
-        </Root>
-        <div className={styles.rightMargin} />
-      </Layout>
-    )
 
-    return ReactDOM.createPortal(content, getDevContainer())
+    return (
+      <configProviderContext.Consumer>
+        {context => {
+          const values = getValues(context)
+          const styles = getStyles(values)
+          const content = (
+            <Layout className={styles.gymnastOverlay}>
+              <div className={styles.leftMargin} />
+              <Root>
+                {times(values.columns).map(key => (
+                  <Grid
+                    margin={[0, values.gutter / 2]}
+                    key={key}
+                    size={1}
+                    className={styles.col}
+                  />
+                ))}
+              </Root>
+              <div className={styles.rightMargin} />
+            </Layout>
+          )
+
+          return ReactDOM.createPortal(content, getDevContainer())
+        }}
+      </configProviderContext.Consumer>
+    )
   }
 }

--- a/src/root/index.js
+++ b/src/root/index.js
@@ -1,25 +1,29 @@
 // @flow
 import * as React from 'react'
 import Grid from '../grid'
-import type { GridProps, ConfigProviderContext } from '../types'
+import type { GridProps } from '../types'
 import getStyles from './root.styles'
 import { getValues } from '../utils'
+import { configProviderContext } from '../configProvider'
 
 type Props = GridProps & {
   children?: React.Node,
 }
 
-export default function Root(
-  { children, justify, ...props }: Props,
-  context: ConfigProviderContext
-) {
-  const styles = getStyles(getValues(context, props))
-
+export default function Root({ children, justify, ...props }: Props) {
   return (
-    <Grid {...props} className={styles.root} justify="center">
-      <Grid justify={justify} className={styles.child}>
-        {children}
-      </Grid>
-    </Grid>
+    <configProviderContext.Consumer>
+      {context => {
+        const styles = getStyles(getValues(context, props))
+
+        return (
+          <Grid {...props} className={styles.root} justify="center">
+            <Grid justify={justify} className={styles.child}>
+              {children}
+            </Grid>
+          </Grid>
+        )
+      }}
+    </configProviderContext.Consumer>
   )
 }

--- a/src/types.js
+++ b/src/types.js
@@ -124,3 +124,16 @@ export type LayoutProps = {
   height?: Height | { [string]: Height },
   overflow?: Overflow | { [string]: Overflow },
 }
+
+type Provider<T> = React.Component<{
+  value: T,
+  children?: React.Node,
+}>
+type Consumer<T> = React.Component<{
+  children: (value: T) => React.Node,
+}>
+
+export type Context<T> = {
+  Provider: Provider<T>,
+  Consumer: Consumer<T>,
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,4 @@
 // @flow
-import { get } from 'lodash'
 import cxs from '../cxs'
 import defaults from '../defaults'
 import type {
@@ -243,16 +242,18 @@ export function toCXS<A>(raw: {
   return styles
 }
 
-export function getValue<A: *>(context: *, property: string, override?: A): A {
-  const contextValue = get(context, `gymnast["${property}"]`)
-
-  return ([override, contextValue, defaults[property]].find(isDefined): any)
+export function getValue<A: *>(
+  context: * = {},
+  property: string,
+  override?: A
+): A {
+  return ([override, context[property], defaults[property]].find(
+    isDefined
+  ): any)
 }
 
-export function getValues(context: *, overrides?: * = {}) {
-  const contextValues = get(context, 'gymnast', {})
-
-  return { ...defaults, ...contextValues, ...overrides }
+export function getValues(context: *, overrides?: *) {
+  return { ...defaults, ...context, ...overrides }
 }
 
 export function accumulateOver(props: Array<string>) {

--- a/src/utils/utils.spec.js
+++ b/src/utils/utils.spec.js
@@ -295,13 +295,13 @@ describe('toCXS', () => {
 
 describe('getValue', () => {
   it('should read the value specified by context', () => {
-    const out = getValue({ gymnast: { columns: 14 } }, 'columns')
+    const out = getValue({ columns: 14 }, 'columns')
 
     expect(out).toBe(14)
   })
 
   it('should prefer the override value when provided', () => {
-    const out = getValue({ gymnast: { columns: 14 } }, 'columns', 20)
+    const out = getValue({ columns: 14 }, 'columns', 20)
 
     expect(out).toBe(20)
   })
@@ -315,26 +315,26 @@ describe('getValue', () => {
 
 describe('getValues', () => {
   it('should return an object', () => {
-    const out = getValues({ gymnast: {} })
+    const out = getValues({})
 
     expect(out).toEqual(jasmine.any(Object))
   })
 
   it('should merge context, overrides and defaults', () => {
-    const out = getValues({ gymnast: { A: 2 } })
+    const out = getValues({ A: 2 })
 
     expect(out.A).toBe(2)
     expect(size(out)).toBeGreaterThan(1)
   })
 
   it('should favor overrides when all are specified', () => {
-    const out = getValues({ gymnast: { columns: 2 } }, { columns: 4 })
+    const out = getValues({ columns: 2 }, { columns: 4 })
 
     expect(out.columns).toBe(4)
   })
 
   it('should favor context when only context and defaults are set', () => {
-    const out = getValues({ gymnast: { columns: 2 } })
+    const out = getValues({ columns: 2 })
 
     expect(out.columns).toBe(2)
   })

--- a/src/withResolution/index.js
+++ b/src/withResolution/index.js
@@ -4,126 +4,33 @@ import type { DisplayValues } from '../types'
 import log from '../log'
 import { getValue } from '../utils'
 import errors from '../errors'
-import { ConfigContextPropTypes } from '../configProvider'
-import { register, unregister, supportsMatchMedia } from './mediaQuery'
-import {
-  checkShouldShow,
-  getMediaQueries,
-  getSingleResolutionProps,
-  hasTrueValues,
-  isObject,
-  type ShouldShow,
-  sharedResolutionProperties,
-} from './withResolution.logic'
+import { supportsMatchMedia } from './mediaQuery'
+import { configProviderContext } from '../configProvider'
+import MediaQueryComponent from './mediaQueryComponent'
 
 type Props = { show?: DisplayValues }
-type State = {
-  shouldShow?: ShouldShow,
-}
 
 export default function withResolution(
   Component: React.ComponentType<*>,
   resolutionKeys: Array<string>,
   coercedSupport?: boolean = supportsMatchMedia
 ) {
-  const combinedResolutionKeys = sharedResolutionProperties.concat(
-    resolutionKeys
-  )
-
   if (!coercedSupport) {
     log.warn(errors.NOMATCHMEDIA)
     return Component
   }
 
-  return class WithResolution extends React.Component<
-    Props & React.ElementProps<typeof Component>,
-    State
-  > {
-    static contextTypes = ConfigContextPropTypes
-
-    constructor(props: Props) {
-      super(props)
-      const queries = this.getQueries(props.show)
-
-      this.state = {
-        shouldShow: checkShouldShow(queries),
-      }
-    }
-
-    componentDidMount() {
-      this.addMediaQueryListener(this.props.show)
-    }
-
-    componentWillReceiveProps({ show }: Props) {
-      if (show !== this.props.show) {
-        this.removeMediaQueryListener(this.props.show)
-        this.addMediaQueryListener(show)
-      }
-    }
-
-    componentWillUnmount() {
-      this.removeMediaQueryListener(this.props.show)
-    }
-
-    onMediaQueryChange = (mq?: any = {}, alias: string) => {
-      const show = this.state.shouldShow || {}
-      if (show[alias] !== mq.matches) {
-        this.setState({
-          shouldShow: {
-            ...show,
-            [alias]: mq.matches,
-          },
-        })
-      }
-    }
-
-    getQueries = (show?: DisplayValues) => {
-      const displayAliases = getValue(this.context, 'displayAliases')
-      let queries = show
-
-      if (!show && this.anyPropsUseResolutionFormat()) {
-        queries = Object.keys(displayAliases)
-      }
-
-      return getMediaQueries(queries, displayAliases)
-    }
-
-    anyPropsUseResolutionFormat = () =>
-      combinedResolutionKeys.some(key => isObject(this.props[key]))
-
-    removeMediaQueryListener = (show?: DisplayValues) => {
-      const queries = this.getQueries(show)
-
-      Object.keys(queries).forEach(alias => {
-        unregister(queries[alias], this.onMediaQueryChange)
-      })
-    }
-
-    addMediaQueryListener = (show?: DisplayValues) => {
-      const queries = this.getQueries(show)
-
-      Object.keys(queries).forEach(alias => {
-        register(queries[alias], alias, this.onMediaQueryChange)
-      })
-    }
-
-    render() {
-      if (
-        this.props.show &&
-        this.state.shouldShow &&
-        !hasTrueValues(this.state.shouldShow)
-      ) {
-        return null
-      }
-
-      const props = getSingleResolutionProps({
-        props: this.props,
-        shouldShow: this.state.shouldShow,
-        resolutionKeys: combinedResolutionKeys,
-        fallbackDisplayKey: getValue(this.context, 'fallbackDisplayKey'),
-      })
-
-      return <Component {...props} />
-    }
-  }
+  return (props: Props & React.ElementProps<typeof Component>) => (
+    <configProviderContext.Consumer>
+      {context => (
+        <MediaQueryComponent
+          {...props}
+          resolutionKeys={resolutionKeys}
+          displayAliases={getValue(context, 'displayAliases')}
+          fallbackDisplayKey={getValue(context, 'fallbackDisplayKey')}
+          component={Component}
+        />
+      )}
+    </configProviderContext.Consumer>
+  )
 }

--- a/src/withResolution/mediaQueryComponent.js
+++ b/src/withResolution/mediaQueryComponent.js
@@ -1,0 +1,112 @@
+// @flow
+import * as React from 'react'
+import type { DisplayValues, DisplayAliases } from '../types'
+import { register, unregister } from './mediaQuery'
+import {
+  checkShouldShow,
+  getMediaQueries,
+  getSingleResolutionProps,
+  hasTrueValues,
+  isObject,
+  type ShouldShow,
+} from './withResolution.logic'
+
+type Props = {
+  +show?: DisplayValues,
+  +fallbackDisplayKey: string,
+  +displayAliases: DisplayAliases,
+  +resolutionKeys: string[],
+}
+type State = {
+  shouldShow?: ShouldShow,
+}
+
+export default class MediaQueryComponent extends React.Component<
+  Props & React.ElementProps<typeof React.Component>,
+  State
+> {
+  constructor(props: Props) {
+    super(props)
+    const queries = this.getQueries(props.show)
+
+    this.state = {
+      shouldShow: checkShouldShow(queries),
+    }
+  }
+
+  componentDidMount() {
+    this.addMediaQueryListener(this.props.show)
+  }
+
+  componentWillReceiveProps({ show }: Props) {
+    if (show !== this.props.show) {
+      this.removeMediaQueryListener(this.props.show)
+      this.addMediaQueryListener(show)
+    }
+  }
+
+  componentWillUnmount() {
+    this.removeMediaQueryListener(this.props.show)
+  }
+
+  onMediaQueryChange = (mq?: any = {}, alias: string) => {
+    const show = this.state.shouldShow || {}
+    if (show[alias] !== mq.matches) {
+      this.setState({
+        shouldShow: {
+          ...show,
+          [alias]: mq.matches,
+        },
+      })
+    }
+  }
+
+  getQueries = (show?: DisplayValues) => {
+    let queries = show
+
+    if (!show && this.anyPropsUseResolutionFormat()) {
+      queries = Object.keys(this.props.displayAliases)
+    }
+
+    return getMediaQueries(queries, this.props.displayAliases)
+  }
+
+  anyPropsUseResolutionFormat = () =>
+    this.props.resolutionKeys.some(key => isObject(this.props[key]))
+
+  removeMediaQueryListener = (show?: DisplayValues) => {
+    const queries = this.getQueries(show)
+
+    Object.keys(queries).forEach(alias => {
+      unregister(queries[alias], this.onMediaQueryChange)
+    })
+  }
+
+  addMediaQueryListener = (show?: DisplayValues) => {
+    const queries = this.getQueries(show)
+
+    Object.keys(queries).forEach(alias => {
+      register(queries[alias], alias, this.onMediaQueryChange)
+    })
+  }
+
+  render() {
+    if (
+      this.props.show &&
+      this.state.shouldShow &&
+      !hasTrueValues(this.state.shouldShow)
+    ) {
+      return null
+    }
+
+    const props = getSingleResolutionProps({
+      props: this.props,
+      shouldShow: this.state.shouldShow,
+      resolutionKeys: this.props.resolutionKeys,
+      fallbackDisplayKey: this.props.fallbackDisplayKey,
+    })
+    const Component = this.props.component
+
+    return <Component {...props} />
+  }
+}

--- a/src/withResolution/withResolution.spec.js
+++ b/src/withResolution/withResolution.spec.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react'
 import { mount } from 'enzyme'
 import log from '../log'
@@ -11,7 +12,7 @@ import { unregister, register } from './mediaQuery'
 
 describe('withResolution', () => {
   let wrapper
-  const Fruit = ({ fruit }) => <div>{fruit}</div>
+  const Fruit = ({ fruit }: {| +fruit: string |}) => <div>{fruit}</div>
 
   it('should be a pass through if matchMedia is not supported', () => {
     spyOn(log, 'warn')

--- a/test/env.js
+++ b/test/env.js
@@ -28,7 +28,7 @@ global.matchMedia = function matchMedia(media) {
 }
 
 const Enzyme = require('enzyme')
-const Adapter = require('enzyme-adapter-react-16')
+const Adapter = require('enzyme-adapter-react-16.3')
 
 Enzyme.configure({ adapter: new Adapter() })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1223,7 +1223,7 @@ babel-core@6.26.0:
     slash "^1.0.0"
     source-map "^0.5.6"
 
-babel-core@^6.0.0, babel-core@^6.25.0, babel-core@^6.26.0:
+babel-core@^6.0.0, babel-core@^6.26.0:
   version "6.26.3"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
   dependencies:
@@ -1489,15 +1489,6 @@ babel-plugin-external-helpers@^6.22.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz#2285f48b02bd5dede85175caf8c62e86adccefa1"
   dependencies:
     babel-runtime "^6.22.0"
-
-babel-plugin-flow-react-proptypes@24.1.1:
-  version "24.1.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-flow-react-proptypes/-/babel-plugin-flow-react-proptypes-24.1.1.tgz#a40088bdcf22bbe7d10fe05dad7edf747940df43"
-  dependencies:
-    babel-core "^6.25.0"
-    babel-template "^6.25.0"
-    babel-traverse "^6.25.0"
-    babel-types "^6.25.0"
 
 babel-plugin-istanbul@^4.0.0, babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
@@ -2262,7 +2253,7 @@ babel-runtime@6.26.0, babel-runtime@6.x.x, babel-runtime@^6.11.6, babel-runtime@
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0, babel-template@^6.26.0:
+babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:
@@ -2272,7 +2263,7 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0, babel-te
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.25.0, babel-traverse@^6.26.0:
+babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   dependencies:
@@ -2294,7 +2285,7 @@ babel-types@7.0.0-beta.3:
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.25.0, babel-types@^6.26.0:
+babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -2582,7 +2573,14 @@ browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
     caniuse-db "^1.0.30000639"
     electron-to-chromium "^1.2.7"
 
-browserslist@^2.0.0, browserslist@^2.1.2, browserslist@^2.11.3:
+browserslist@^2.0.0:
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.1.tgz#02fda29d9a2164b879100126e7b0d0b57e43a7bb"
+  dependencies:
+    caniuse-lite "^1.0.30000789"
+    electron-to-chromium "^1.3.30"
+
+browserslist@^2.1.2, browserslist@^2.11.3:
   version "2.11.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
   dependencies:
@@ -2818,15 +2816,25 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   version "1.0.30000877"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000877.tgz#29ea435fdbe8a671cc5b027a75e28a816c17c340"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000876, caniuse-lite@^1.0.30000877:
+caniuse-lite@^1.0.0:
+  version "1.0.30000789"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000789.tgz#2e3d937b267133f63635ef7f441fac66360fc889"
+
+caniuse-lite@^1.0.30000789:
+  version "1.0.30000810"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000810.tgz#47585fffce0e9f3593a6feea4673b945424351d9"
+
+caniuse-lite@^1.0.30000792:
+  version "1.0.30000792"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz#d0cea981f8118f3961471afbb43c9a1e5bbf0332"
+
+caniuse-lite@^1.0.30000805:
+  version "1.0.30000808"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000808.tgz#7d759b5518529ea08b6705a19e70dbf401628ffc"
+
+caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000876, caniuse-lite@^1.0.30000877:
   version "1.0.30000877"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000877.tgz#f189673b86ecc06436520e3e391de6a13ca923b4"
-
-capture-exit@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-1.2.0.tgz#1c5fcc489fd0ab00d4f1ac7ae1072e3173fbab6f"
-  dependencies:
-    rsvp "^3.3.3"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -3252,7 +3260,7 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.17.x, commander@^2.11.0, commander@^2.13.0, commander@^2.15.0, commander@^2.9.0:
+commander@2.17.x, commander@^2.15.0:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
 
@@ -3265,6 +3273,10 @@ commander@2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+commander@^2.11.0, commander@^2.13.0, commander@^2.9.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
 
 commander@~2.14.1:
   version "2.14.1"
@@ -3842,6 +3854,10 @@ deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
 
+deep-extend@~0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
+
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -4084,9 +4100,16 @@ domutils@1.1:
   dependencies:
     domelementtype "1"
 
-domutils@1.5.1, domutils@^1.5.1:
+domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.6.2.tgz#1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff"
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -4165,7 +4188,21 @@ ejs@2.5.7, ejs@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
 
-electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.57:
+electron-releases@^2.1.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/electron-releases/-/electron-releases-2.8.0.tgz#643c27ab116b608e4244e6b5a07fbf798453f590"
+
+electron-to-chromium@^1.2.7:
+  version "1.3.30"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz#9666f532a64586651fc56a72513692e820d06a80"
+  dependencies:
+    electron-releases "^2.1.0"
+
+electron-to-chromium@^1.3.30:
+  version "1.3.32"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.32.tgz#11d0684c0840e003c4be8928f8ac5f35dbc2b4e6"
+
+electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.57:
   version "1.3.59"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.59.tgz#6377db04d8d3991d6286c72ed5c3fde6f4aaf112"
 
@@ -4241,18 +4278,18 @@ env-ci@^2.0.0:
     execa "^0.10.0"
     java-properties "^0.2.9"
 
-enzyme-adapter-react-16@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.2.0.tgz#c6e80f334e0a817873262d7d01ee9e4747e3c97e"
+enzyme-adapter-react-16.3@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16.3/-/enzyme-adapter-react-16.3-1.0.0.tgz#d3992301aba46c8cceab21c1d201e85f01c93bfc"
   dependencies:
     enzyme-adapter-utils "^1.5.0"
     function.prototype.name "^1.1.0"
     object.assign "^4.1.0"
     object.values "^1.0.4"
     prop-types "^15.6.2"
-    react-is "^16.4.2"
+    react-is "^16.4.1"
     react-reconciler "^0.7.0"
-    react-test-renderer "^16.0.0-0"
+    react-test-renderer "~16.3.0-0"
 
 enzyme-adapter-utils@^1.5.0:
   version "1.5.0"
@@ -5022,13 +5059,9 @@ fileset@^2.0.2:
     glob "^7.0.3"
     minimatch "^3.0.3"
 
-filesize@3.5.11:
+filesize@3.5.11, filesize@^3.5.11:
   version "3.5.11"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.11.tgz#1919326749433bb3cf77368bd158caabcc19e9ee"
-
-filesize@^3.5.11:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.1.tgz#090bb3ee01b6f801a8a8be99d31710b3422bb317"
 
 fill-range@^2.1.0:
   version "2.2.4"
@@ -5277,7 +5310,7 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-fsevents@^1.0.0, fsevents@^1.2.2, fsevents@^1.2.3:
+fsevents@^1.0.0, fsevents@^1.1.1, fsevents@^1.2.2:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
   dependencies:
@@ -10572,6 +10605,10 @@ process-es6@^0.11.2, process-es6@^0.11.6:
   version "0.11.6"
   resolved "https://registry.yarnpkg.com/process-es6/-/process-es6-0.11.6.tgz#c6bb389f9a951f82bd4eb169600105bd2ff9c778"
 
+process-nextick-args@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+
 process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
@@ -10871,11 +10908,20 @@ raw-loader@0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-0.5.1.tgz#0c3d0beaed8a01c966d9787bf778281252a979aa"
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
+rc@^1.0.1, rc@^1.2.7, rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   dependencies:
     deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
+rc@^1.1.6:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.3.tgz#51575a900f8dd68381c710b4712c2154c3e2035b"
+  dependencies:
+    deep-extend "~0.4.0"
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
@@ -11000,7 +11046,7 @@ react-inspector@^2.2.2:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
-react-is@^16.4.2:
+react-is@^16.3.2, react-is@^16.4.1, react-is@^16.4.2:
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
 
@@ -11045,7 +11091,7 @@ react-style-proptype@^3.0.0:
   dependencies:
     prop-types "^15.5.4"
 
-react-test-renderer@16.4.2, react-test-renderer@^16.0.0-0:
+react-test-renderer@16.4.2:
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.4.2.tgz#4e03eca9359bb3210d4373f7547d1364218ef74e"
   dependencies:
@@ -11053,6 +11099,15 @@ react-test-renderer@16.4.2, react-test-renderer@^16.0.0-0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
     react-is "^16.4.2"
+
+react-test-renderer@~16.3.0-0:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.2.tgz#3d1ed74fda8db42521fdf03328e933312214749a"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+    react-is "^16.3.2"
 
 react-textarea-autosize@^5.2.1:
   version "5.2.1"
@@ -11192,16 +11247,16 @@ read@1, read@~1.0.1, read@~1.0.7:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@2, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+"readable-stream@1 || 2", readable-stream@2, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
     isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
+    process-nextick-args "~1.0.6"
     safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
+    string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
 readable-stream@1.0, readable-stream@~1.0.26, readable-stream@~1.0.26-4:
@@ -11221,6 +11276,18 @@ readable-stream@1.1.x, readable-stream@^1.0.26-4, readable-stream@~1.1.10:
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
+
+readable-stream@^2.3.0, readable-stream@^2.3.5, readable-stream@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
 
 readdir-scoped-modules@^1.0.0:
   version "1.0.2"
@@ -11787,10 +11854,6 @@ rst-selector-parser@^2.2.3:
     lodash.flattendeep "^4.4.0"
     nearley "^2.7.10"
 
-rsvp@^3.3.3:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
-
 run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
@@ -11848,19 +11911,18 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
 sane@^2.0.0:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/sane/-/sane-2.5.2.tgz#b4dc1861c21b427e929507a3e751e2a2cb8ab3fa"
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/sane/-/sane-2.3.0.tgz#3f3df584abf69e63d4bb74f0f8c42468e4d7d46b"
   dependencies:
-    anymatch "^2.0.0"
-    capture-exit "^1.2.0"
+    anymatch "^1.3.0"
     exec-sh "^0.2.0"
     fb-watchman "^2.0.0"
-    micromatch "^3.1.4"
+    minimatch "^3.0.2"
     minimist "^1.1.1"
     walker "~1.0.5"
     watch "~0.18.0"
   optionalDependencies:
-    fsevents "^1.2.3"
+    fsevents "^1.1.1"
 
 saucelabs@1.4.0:
   version "1.4.0"
@@ -11981,7 +12043,15 @@ semver-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-1.0.0.tgz#92a4969065f9c70c694753d55248fc68f8f652c9"
 
-"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
+"semver@2 >=2.2.1 || 3.x || 4 || 5", semver@^5.1.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+"semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3, semver@^5.5.0:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
@@ -12604,6 +12674,12 @@ string_decoder@^1.0.0, string_decoder@~1.1.1:
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+
+string_decoder@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+  dependencies:
+    safe-buffer "~5.1.0"
 
 stringify-entities@^1.0.1:
   version "1.3.2"


### PR DESCRIPTION
Context tests need to be updated

These changes require at least React 16.3 and remove the prop-types dependency

#### TODO

- [ ] Fix tests
- [ ] Check / Add story showcasing any context changes
- [ ] Fix react props being passed down to DOM elements

BREAKING CHANGE