### PR TITLE
fix(flow): Remove generic logger

### DIFF
--- a/src/gymnast.js
+++ b/src/gymnast.js
@@ -18,7 +18,6 @@ export { default as withContext } from './withContext'
 
 // Utils / Dev
 export { default as Dev } from './dev'
-export { default as log } from './log'
 export { default as defaults } from './defaults'
 export { default as utils } from './utils'
 

--- a/test/e2e/__snapshots__/gymnast.spec.js.snap
+++ b/test/e2e/__snapshots__/gymnast.spec.js.snap
@@ -67,13 +67,6 @@ Object {
     },
     "verticalGutter": 3,
   },
-  "log": Object {
-    "error": [Function],
-    "info": [Function],
-    "setLevel": [Function],
-    "setLogger": [Function],
-    "warn": [Function],
-  },
   "utils": Object {
     "accumulateOver": [Function],
     "combineSpacing": [Function],


### PR DESCRIPTION
The generic "log" exported can easily cause issues with other loggers in flow

Since this utility was unused and provides no customitzation value (it's noop'ed
on the minified build), removing as a direct export