### PR TITLE
feat(flow): Generate flow types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,6 +27,7 @@
       "url": "http://json.schemastore.org/tsconfig"
     }
   ],
+  "javascript.validate.enable": false,
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
   "prettier.semi": false,

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ or
 
 [Play with a demo](https://codesandbox.io/s/github/gymnastjs/playground)
 
-If you are migrating from gymnast 16, check the [migration guide](https://gymnast.readme.io/v17/blog/migration-guide-v16-to-v17).
+To install the development branch of gymnast, run `yarn add gymnast@next`.
+
+If you are migrating from gymnast 16, check the [migration guide](https://gymnast.readme.io/v17/blog/16-to-17-guide).
 
 ## 📺 Examples
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-plugin-typescript": "0.14.0",
     "extract-text-webpack-plugin": "3.0.2",
     "find-up": "3.0.0",
+    "flowgen": "1.8.0",
     "html-loader": "0.5.5",
     "ignore-loader": "0.1.2",
     "jest": "24.7.1",
@@ -127,6 +128,7 @@
   "scripts": {
     "build:dev": "cross-env NODE_ENV=development webpack --config scripts/webpack.config.js --mode=development",
     "build:min": "cross-env NODE_ENV=production webpack --config scripts/webpack.config.js --mode=production",
+    "build:flowtypes": "./scripts/flowgen.sh",
     "build": "npm-run-all --parallel build:*",
     "clean:image": "find storybook/stories -name \"*.png\" -type f -delete && find storybook/stories -name __screenshots__ -type d -exec rm -rf {} \\;",
     "contributors:add": "all-contributors add",

--- a/scripts/flowgen.sh
+++ b/scripts/flowgen.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eu
+
+#
+# Generates flow type definitions based on TypeScript types
+#
+
+# Remove any previous flow files
+rm -f dist/{,**/}*.flow
+
+# Generate flow global type definitions
+yarn flowgen src/types.d.ts -o dist/flowTypes.js --add-flow-header
+
+# Copy flow exports
+cp src/flow.js dist/gymnast.js.flow

--- a/src/flow.js
+++ b/src/flow.js
@@ -1,0 +1,34 @@
+// @flow
+/* eslint-disable */
+import * as React from 'react'
+// `flowTypes` is generated on build in the dist/ folder based on `types.d.ts`
+import * as Types from './flowTypes'
+
+declare module 'gymnast' {
+  // Components
+  declare const Col: React.StatelessFunctionalComponent<Types.GridProps>
+  declare const Grid: React.StatelessFunctionalComponent<Types.GridProps>
+  declare const GymnastProvider: React.StatelessFunctionalComponent<Types.GymnastContextType & { children?: React.ReactNode }>
+
+  // Hooks
+  declare function useGrid<A = {}>(props: Types.GridProps & A): [boolean, Types.GridProps & A]
+
+  // Globals
+  declare const defaults: ConfigDefaults
+  declare const log: Types.Logger & {
+    setLevel: (level: 'info' | 'warn' | 'error') => void,
+    setLogger: (newLogger: Logger) => void
+  }
+
+  // Types
+  declare type AlignValues = Types.AlignValues
+  declare type DisplayAliases = Types.DisplayAliases
+  declare type DisplayValues = Types.DisplayValues
+  declare type DirectionValues = Types.DirectionValues
+  declare type GridProps = Types.GridProps
+  declare type GridRef = Type.GridRef
+  declare type Size = Types.Size
+  declare type Spacing = Types.Spacing
+  declare type SpacingProps = Types.SpacingProps
+  declare type SpacingValues = Types.SpacingValues
+}

--- a/src/gymnast.tsx
+++ b/src/gymnast.tsx
@@ -7,13 +7,12 @@ export { default as Grid } from './grid'
 
 // Hooks
 export { default as useGrid } from './useGrid'
-export { default as useResolution } from './useResolution'
 
-// Utils
+// Globals
 export { default as defaults } from './defaults'
 export { default as log } from './log'
-export { default as utils } from './utils'
 
+// Types
 export {
   AlignValues,
   DisplayAliases,

--- a/src/log/index.spec.tsx
+++ b/src/log/index.spec.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
-import log, { Logger } from './index'
+import log from './index'
+import { Logger } from '../types'
 
 describe('log', () => {
   let logger: Logger

--- a/src/log/index.tsx
+++ b/src/log/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { errors } from '../errors'
+import { Logger } from '../types'
 
-export type Logger = { info: Function; warn: Function; error: Function }
 const logLevels = ['info', 'warn', 'error']
 let logIndex = 0
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -94,3 +94,9 @@ export interface ConfigDefaults extends GymnastContextType {
 }
 
 export type GridRef = React.Ref<HTMLDivElement>
+
+export type Logger = {
+  info: (...args: any[]) => void
+  warn: (...args: any[]) => void
+  error: (...args: any[]) => void
+}

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -254,7 +254,7 @@ export function getValue<A>(
   return [override, context[property], defaults[property]].find(isDefined)
 }
 
-export function getValues<C extends object, D extends object>(
+export function getValues<C extends {}, D extends {}>(
   context?: C,
   overrides?: D
 ): ConfigDefaults {

--- a/storybook/stories/grid/resolution.tsx
+++ b/storybook/stories/grid/resolution.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Grid } from 'gymnast'
 import { colors } from '../../shared'
 
-class Button extends React.Component<object, { counter: number }> {
+class Button extends React.Component<{}, { counter: number }> {
   state = { counter: 0 }
 
   onClick = () => this.setState(({ counter }) => ({ counter: counter + 1 }))

--- a/test/e2e/__snapshots__/gymnast.spec.tsx.snap
+++ b/test/e2e/__snapshots__/gymnast.spec.tsx.snap
@@ -78,20 +78,5 @@ Object {
     "warn": [Function],
   },
   "useGrid": [Function],
-  "useResolution": [Function],
-  "utils": Object {
-    "accumulateOver": [Function],
-    "combineSpacing": [Function],
-    "getCSS": [Function],
-    "getValue": [Function],
-    "getValues": [Function],
-    "noop": [Function],
-    "parseSpacing": [Function],
-    "replaceSpacingAliases": [Function],
-    "splitPattern": /\\(\\?:\\(\\?:\\\\s\\+\\)\\?,\\(\\?:\\\\s\\+\\)\\?\\|\\\\s\\+\\)/,
-    "times": [Function],
-    "toCXS": [Function],
-    "validateSpacingProps": [Function],
-  },
 }
 `;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,6 @@
     }
   },
   "compileOnSave": true,
-  "include": ["src", "test", "types", "storybook"]
+  "include": ["src", "test", "types", "storybook"],
+  "exclude": ["src/flow.js"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6479,6 +6479,19 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
   integrity sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=
 
+flowgen@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/flowgen/-/flowgen-1.8.0.tgz#e1c7d493c7a868a0181ec92a92812de4f418780f"
+  integrity sha512-Ywl72S0TEcou9bcwPKdCKDcBPNovTEsXO3lZRCkdvaZMSNDWpB+cZ210RJmpAsDcTyCftbbnW1Wh+mbc1mr/cg==
+  dependencies:
+    commander "^2.11.0"
+    lodash "^4.17.4"
+    paralleljs "^0.2.1"
+    prettier "^1.16.4"
+    shelljs "^0.8.3"
+    typescript "^3.3.3333"
+    typescript-compiler "^1.4.1-2"
+
 flush-write-stream@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
@@ -10956,6 +10969,11 @@ parallel-transform@^1.1.0:
     inherits "^2.0.3"
     readable-stream "^2.1.5"
 
+paralleljs@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/paralleljs/-/paralleljs-0.2.1.tgz#ebca745d3e09c01e2bebcc14858891ff4510e926"
+  integrity sha1-68p0XT4JwB4r68wUhYiR/0UQ6SY=
+
 param-case@2.1.x:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247"
@@ -11756,7 +11774,7 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@1.16.4:
+prettier@1.16.4, prettier@^1.16.4:
   version "1.16.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
   integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
@@ -13434,7 +13452,7 @@ shell-quote@1.6.1, shell-quote@^1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
-shelljs@^0.8.2:
+shelljs@^0.8.2, shelljs@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
   integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
@@ -14622,7 +14640,12 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.4.3:
+typescript-compiler@^1.4.1-2:
+  version "1.4.1-2"
+  resolved "https://registry.yarnpkg.com/typescript-compiler/-/typescript-compiler-1.4.1-2.tgz#ba4f7db22d91534a1929d90009dce161eb72fd3f"
+  integrity sha1-uk99si2RU0oZKdkACdzhYety/T8=
+
+typescript@3.4.3, typescript@^3.3.3333:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.3.tgz#0eb320e4ace9b10eadf5bc6103286b0f8b7c224f"
   integrity sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==


### PR DESCRIPTION
Generates flow types based on typescript definitions.

- `flowgen` is on early development and fails for many files. Instead it's used only to convert the `types.d.ts` files.
- This simplifies the work but `src/flow.js` is generated and maintained manually
- Removes `utils` and `useResolution` exports since they were undocumented, unused externally and more work to type 😛 
- This is a first pass, as soon as a beta version is released we can start testing consumption