### PR TITLE
remove unused ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gymnast",
-  "version": "17.0.0-next.7",
+  "version": "17.0.0-next.11",
   "description": "Configurable grid for React",
   "main": "index.js",
   "unpkg": "dist/gymnast.min.js",

--- a/src/col.tsx
+++ b/src/col.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import useGrid from './useGrid'
-import { GridProps, OneResolutionGrid, GridRef } from './types'
+import { GridDivProps, OneResolutionGrid } from './types'
 
 const defaultProps: OneResolutionGrid = {
   marginTop: 0,
@@ -9,9 +9,9 @@ const defaultProps: OneResolutionGrid = {
   marginLeft: 'gutter/2',
 }
 
-const forwardRef = React.forwardRef(function Col(
-  props: Partial<JSX.IntrinsicElements['div'] & GridProps & { ref: GridRef }>,
-  ref: GridRef
+const forwardRef = React.forwardRef<HTMLDivElement, GridDivProps>(function Col(
+  props,
+  ref
 ) {
   const colProps =
     props.margin !== undefined

--- a/src/grid.tsx
+++ b/src/grid.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 import useGrid from './useGrid'
-import { GridProps, GridRef } from './types'
+import { GridDivProps } from './types'
 
-const forwardRef = React.forwardRef(function Grid(
-  props: Partial<JSX.IntrinsicElements['div'] & GridProps & { ref: GridRef }>,
-  ref: GridRef
+const forwardRef = React.forwardRef<HTMLDivElement, GridDivProps>(function Grid(
+  props,
+  ref
 ) {
   const [shouldShow, gridProps] = useGrid(props)
 

--- a/src/gymnast.tsx
+++ b/src/gymnast.tsx
@@ -19,7 +19,6 @@ export {
   DisplayValues,
   DirectionValues,
   GridProps,
-  GridRef,
   Size,
   Spacing,
   SpacingProps,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -87,13 +87,19 @@ export type GridProps = {
   style?: React.CSSProperties
 }
 
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+type DivProps = Omit<
+  JSX.IntrinsicElements['div'],
+  'onAuxClick' | 'onAuxClickCapture'
+>
+
+export type GridDivProps = Partial<DivProps & GridProps>
+
 export interface ConfigDefaults extends GymnastContextType {
   gutter: number
   verticalGutter: number
   base: number
 }
-
-export type GridRef = React.Ref<HTMLDivElement>
 
 export type Logger = {
   info: (...args: any[]) => void

--- a/test/e2e/__snapshots__/gymnast.spec.tsx.snap
+++ b/test/e2e/__snapshots__/gymnast.spec.tsx.snap
@@ -17,7 +17,6 @@ Object {
     "render": [Function],
   },
   "GridProps": undefined,
-  "GridRef": undefined,
   "GymnastProvider": [Function],
   "Size": undefined,
   "Spacing": undefined,


### PR DESCRIPTION
- Removes unused ref type
- Fixes (hopefully) TS types. TS types still seem to be broken when imported but they work when linking

Types works well when using `yarn link gymnast` on a separate project but not when installing the package. It's not that it can't find the package, the types are there but fail with `'onAuxClick' | 'onAuxClickCapture'` keys. Current attempt is to just remove them from the type for now

**next.11 update**: Local projects seem to be working as expected but codesandbox.io still fails to find the package (https://codesandbox.io/s/39kww200p)