### PR TITLE
fix(build): transpile to ES5

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "contributors:add": "all-contributors add",
     "contributors:gen": "all-contributors generate",
     "format": "prettier --write \"{src,test,types,scripts,storybook}/**/*.{js,tsx,ts}\"",
-    "lint:tsc": "tsc --noEmit",
+    "lint:tsc": "tsc",
     "lint:eslint": "eslint scripts src/{**/,}*.tsx storybook test --fix",
     "lint": "npm-run-all --parallel lint:*",
     "start:storybook": "start-storybook -p 9001 -c storybook",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
+    "outDir": "dist",
     "declaration": true,
+    "emitDeclarationOnly": true,
     "esModuleInterop": true,
     "isolatedModules": false,
     "jsx": "react",


### PR DESCRIPTION
Export module bundle as ES5 by preventing babel and TS from overwriting each other (no need for TS to export anything other than definition files)